### PR TITLE
fix: add tooltip positions for status bar menu buttons & change menu width

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "mysnippets-plugin",
   "name": "MySnippets",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "minAppVersion": "0.15.3",
   "description": "MySnippets is a plugin that adds a status bar menu allowing the user to quickly toggle their snippets on and off 🖌.",
   "author": "chetachi",

--- a/src/plugin/main.ts
+++ b/src/plugin/main.ts
@@ -37,6 +37,7 @@ export default class MySnippetsPlugin extends Plugin {
     setAttributes(this.statusBarIcon, {
       "aria-label": "Configure Snippets",
       "aria-label-position": "top",
+      "data-tooltip-position":"top"
     });
     setIcon(this.statusBarIcon, "pantone-line");
 

--- a/src/ui/snippetsMenu.ts
+++ b/src/ui/snippetsMenu.ts
@@ -47,6 +47,8 @@ export default function snippetsMenu(
           customCss.setCssEnabledStatus(snippet, !isEnabled);
         }
 
+        setAttributes(buttonComponent.buttonEl, {"data-tooltip-position":"top"});
+
         toggleComponent
           .setValue(customCss.enabledSnippets.has(snippet))
           .onChange(changeSnippetStatus);
@@ -79,8 +81,9 @@ export default function snippetsMenu(
       const folderButton = new ButtonComponent(actionsDom);
       const addButton = new ButtonComponent(actionsDom);
 
-      setAttributes(reloadButton.buttonEl, { style: "margin-right: 3px" });
-      setAttributes(addButton.buttonEl, { style: "margin-left: 3px" });
+      setAttributes(reloadButton.buttonEl, { "data-tooltip-position":"top", style: "margin-right: 3px" });
+      setAttributes(folderButton.buttonEl, {"data-tooltip-position":"top"});
+      setAttributes(addButton.buttonEl, { "data-tooltip-position":"top", style: "margin-left: 3px" });
 
       reloadButton
         .setIcon("ms-reload")

--- a/styles.css
+++ b/styles.css
@@ -28,7 +28,7 @@ STATUS BAR MENU
 }
 
 .MySnippets-statusbar-menu {
-  width: 290px;
+  width: fit-content;
   max-height: calc(100% - 90px);
 }
 


### PR DESCRIPTION
Tooltips for the status bar icon and menu had no explicit "data-tooltip-position" attribute set, causing them all to be auto-positioned as "bottom" when invoked.

This change adds `setAttributes({"data-tooltip-position":"top"})` to the status bar button and all the menu buttons.

&nbsp;
### Screenshots from before the change
> [!NOTE]
> ![before - status bar](https://github.com/chetachiezikeuzor/MySnippets-Plugin/assets/56155501/1ff1bb75-7487-4bed-b089-2f8c013f9f04)
> ![before - Reload snippets](https://github.com/chetachiezikeuzor/MySnippets-Plugin/assets/56155501/fbbdeddf-c353-4707-86d1-414f1c2eea61)
> ![before - Open snippets folder](https://github.com/chetachiezikeuzor/MySnippets-Plugin/assets/56155501/50b187b9-5ab5-4042-beb7-d6067a1778d0)
> ![before - Create new snippet](https://github.com/chetachiezikeuzor/MySnippets-Plugin/assets/56155501/19d4450b-2ea7-4251-bed1-515c7057866d)
> ![before - Open snippet](https://github.com/chetachiezikeuzor/MySnippets-Plugin/assets/56155501/e1bb959a-9024-42af-93e2-18340e595c00)

&nbsp;
### Screenshots from after the change
> [!NOTE]
> ![after - status bar](https://github.com/chetachiezikeuzor/MySnippets-Plugin/assets/56155501/ec4fcebc-d624-427e-8718-0521aff9d637)
> ![after - Reload snippets](https://github.com/chetachiezikeuzor/MySnippets-Plugin/assets/56155501/c6e6238e-52bf-4ca0-8604-d418d60d1f0b)
> ![after - Open snippets folder](https://github.com/chetachiezikeuzor/MySnippets-Plugin/assets/56155501/4438c827-f88d-41ce-977d-0a5d11feb249)
> ![after - Create new snippet](https://github.com/chetachiezikeuzor/MySnippets-Plugin/assets/56155501/b8ae6e74-87e8-400d-930f-733c920f3624)
> ![after - Open snippet](https://github.com/chetachiezikeuzor/MySnippets-Plugin/assets/56155501/2c62490f-1d5a-4b17-9a8f-9b6790a7e9ba)